### PR TITLE
Remove reload from onStart handler

### DIFF
--- a/bin/reload.sh
+++ b/bin/reload.sh
@@ -1,19 +1,53 @@
 #!/bin/bash
 
 SERVICE_NAME=${SERVICE_NAME:-nginx}
+CONSUL=${CONSUL:-consul}
 
-if [ -z "${NGINX_CONF}" ]; then
-    # fetch latest Nginx configuration template from Consul k/v
-    curl -s --fail consul:8500/v1/kv/${SERVICE_NAME}/template?raw > /tmp/nginx.ctmpl
-else
-    # dump the ${NGINX_CONF} environment variable as a file
-    # the quotes are important here to preserve newlines!
-    echo "${NGINX_CONF}" > /tmp/nginx.ctmpl
-fi
+# Render Nginx configuration template using values from Consul,
+# but do not reload because Nginx has't started yet
+preStart() {
+    getConfig
+    consul-template \
+        -once \
+        -consul ${CONSUL}:8500 \
+        -template "/tmp/nginx.ctmpl:/etc/nginx/nginx.conf"
+}
 
-# render Nginx configuration template using values from Consul,
+# Render Nginx configuration template using values from Consul,
 # then gracefully reload Nginx
-consul-template \
-    -once \
-    -consul consul:8500 \
-    -template "/tmp/nginx.ctmpl:/etc/nginx/nginx.conf:nginx -s reload || true"
+onChange() {
+    getConfig
+    consul-template \
+        -once \
+        -consul ${CONSUL}:8500 \
+        -template "/tmp/nginx.ctmpl:/etc/nginx/nginx.conf:nginx -s reload"
+}
+
+getConfig() {
+    if [ -z "${NGINX_CONF}" ]; then
+        # fetch latest Nginx configuration template from Consul k/v
+        curl -s --fail ${CONSUL}:8500/v1/kv/${SERVICE_NAME}/template?raw > /tmp/nginx.ctmpl
+    else
+        # dump the ${NGINX_CONF} environment variable as a file
+        # the quotes are important here to preserve newlines!
+        echo "${NGINX_CONF}" > /tmp/nginx.ctmpl
+    fi
+}
+
+help() {
+    echo "Usage: ./reload.sh preStart  => first-run configuration for Nginx"
+    echo "       ./reload.sh onChange  => [default] update Nginx config on upstream changes"
+}
+
+until
+    cmd=$1
+    if [ -z "$cmd" ]; then
+        onChange
+    fi
+    shift 1
+    $cmd "$@"
+    [ "$?" -ne 127 ]
+do
+    onChange
+    exit
+done

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -1,6 +1,6 @@
 {
   "consul": "consul:8500",
-  "onStart": "/opt/containerbuddy/reload.sh",
+  "onStart": "/opt/containerbuddy/reload.sh preStart",
   "services": [
     {
       "name": "nginx",


### PR DESCRIPTION
For https://github.com/tgross/triton-nginx/issues/6 which is for https://github.com/tgross/triton-elk/pull/2#discussion_r56562539

Split the reload.sh script into a `preStart` which does not fire an Nginx reload and an `onChange` that does. The `onChange` will be the default if no argument is passed so that existing blueprints that are using this container as-is aren't broken.

cc @misterbisson

